### PR TITLE
More in depth correction of the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Privacy Possum monkey wrenches common commercial tracking methods by reducing an
 
 # Threat Model
 
-__Privacy Possum does not have a threat model.__ Weird huh? We prioritize costing tracking companies money over protecting you. When considering some anti-tracking measure we do not ask "Is it possible to circumvent this?". Instead we ask "Is it cost-effective for a tracking company to circumvent this?". If the answer is "yes, no" we accept it.
+__Privacy Possum does not have a threat model.__ Weird huh? We prioritize costing tracking companies money over protecting you. When considering some anti-tracking measure we do not ask “Is it possible to circumvent this?”. Instead, we ask “Is it cost-effective for a tracking company to circumvent this?”. If the answer is “yes, no” we accept it.
 
 Tracking companies are growing, they own more infrastructure, and make more money than ever. This means they have a growing economic, technical, and political influence. And they are guiding the internet into a ever less private place.
 
-We think tackling the problem from an economic angle is extremely important, and will ultimately help shift the internet into more private place.
+We think tackling the problem from an economic angle is crucial, and will ultimately help shift the internet into more private place.
 
 
 # Related Projects
@@ -42,13 +42,13 @@ Comparisons with other anti-tracking projects can be found [here](docs/).
 
 Sites can inspect aspects of your browser itself to determine its uniqueness, and therefore track you. This tracking technique is widely used.
 
-Privacy Badger's fingerprinting blocking has a large deficiency, when fingerprinting is detected, the *origin* is marked as tracking (not the URL). So everything from that origin is blocked in a 3rd party context. This is a problem because it can lead you to block everything from a cdn. To get around this, Privacy Badger adds CDN's to the "cookieblock list". This prevents cookies from being sent to origin's on the list. However, it then *prevents* fingerprinting scripts from being blocked, thus allowing fingerprinting.
+Privacy Badger's fingerprinting blocking has a large deficiency, when fingerprinting is detected, the *origin* is marked as tracking (not the URL). So, everything from that origin is blocked in a 3rd party context. This is a problem because it can lead you to block everything from a CDN. To get around this, Privacy Badger adds CDN's to the “cookieblock list”. This prevents cookies from being sent to origin's on the list. However, it then *prevents* fingerprinting scripts from being blocked, thus allowing fingerprinting.
 
-For example [many sites](https://publicwww.com/websites/cdn.jsdelivr.net%2Fnpm%2Ffingerprintjs2/) load fingerprintjs2 from the jsdelivr CDN, but this is on Privacy Badger's [cookie block list](https://github.com/EFForg/privacybadger/blob/08b61e85e5c361fe8b535ec9e33950431e28632a/src/data/yellowlist.txt#L314). So Privacy Badger will allow sites to load this script fingerprint you.
+For example, [many sites](https://publicwww.com/websites/cdn.jsdelivr.net%2Fnpm%2Ffingerprintjs2/) load fingerprintjs2 from the jsdelivr CDN, but this is on Privacy Badger's [cookie block list](https://github.com/EFForg/privacybadger/blob/08b61e85e5c361fe8b535ec9e33950431e28632a/src/data/yellowlist.txt#L314). So, Privacy Badger will allow sites to load this script fingerprint you.
 
 Fingerprinting usually aggregates information across many esoteric browser API's, so we watch for this behavior. When we detect it, we block it.
 
-However many sites load first party fingerprinting code alongside other necessary code, like on reddit.com, so we can't simply block the script, or it will break the page. Instead when we see first party fingerprinting, we inject random data to spoil the fingerprint. Visit [valve.github.io/fingerprintjs2](https://valve.github.io/fingerprintjs2/) to see this. "get your fingerprint" multiple times, and see it change each time.
+However, many sites load first party fingerprinting code alongside other necessary code, like on reddit.com, so we can't simply block the script, or it will break the page. Instead, when we see first party fingerprinting, we inject random data to spoil the fingerprint. Visit [valve.github.io/fingerprintjs2](https://valve.github.io/fingerprintjs2/) to see this. “Get your fingerprint” multiple times, and see it change each time.
 
 ## Cookie Tracking
 
@@ -58,35 +58,35 @@ Privacy Possum blocks all 3rd party cookies.
 
 ## Etag Tracking
 
-Etags are a well known tracking vector, commonly used in lieu of cookies. 
+Etags are a well-known tracking vector, commonly used in lieu of cookies. 
 
 We detect and block third party etags as follows:
-* The first time you see a request to a 3rd party url with an etag, strip the etag header and store its value.
-* The second time you see a 3rd party request to this url, compare the new etag you get with the old one.
-     - If they are the same, this is not a tracking etag, allow etags for this url now and in the future.
-     - If they are different, do not allow etags for this url now or in the future.
+* The first time you see a request to a 3rd party URL with an etag, strip the etag header and store its value.
+* The second time you see a 3rd party request to this URL, compare the new etag you get with the old one.
+     - If they are the same, this is not a tracking etag, allow etags for this URL now and in the future.
+     - If they are different, do not allow etags for this URL now or in the future.
 
 Chrome withholds the `if-none-match` headers from `onBeforeSendHeaders` (https://developer.chrome.com/extensions/webRequest#Life_cycle_of_requests).
-So we can't prevent the browser from revealing some data via sending cache information, we are only able to intercept incoming etags from sources that are not already cached.
+So, we can't prevent the browser from revealing some data via sending cache information, we can only intercept incoming etags from sources that are not already cached.
 
 ## Referer headers
 
-Referer headers are not exactly used for tracking themselves. But they are used in conjunction with other methods to track you. So we block them, and use a simple algorithm to unblock them when this causes problems.
+Referer headers are not exactly used for tracking themselves. But they are used with other methods to track you. So, we block them, and use a simple algorithm to unblock them when this causes problems.
 * Block `referer` headers to 3rd party sources
 * If the source responds with bad status code, we retry with the header added back in
 
 ## 301 Moved Permanent Redirect Tracking
 
-If you visit a site, it might load a resource that has a 301 redirect. The resource can redirect you to url that is *unique* to you. Then, the next time you see the original resource, your browser will load the unique url from the cache, and fetch the resource from there. Making you uniquely identified.
+If you visit a site, it might load a resource that has a 301 redirect. The resource can redirect you to URL that is *unique* to you. Then, the next time you see the original resource, your browser will load the unique URL from the cache, and fetch the resource from there. Making you uniquely identified.
 
-This is a well known technique, but its pervasiveness is unknown to me.
+This is a well-known technique, but its pervasiveness is unknown to me.
 
 One solution to this would be to use cached 301 redirects from 3rd party sources.
 
-However we have not found a way to disable the cache like this in chrome's extension api. It is possible to intercept the redirect, but if you redirect back to the original url, you fetch from the cache again.
-One hack to disable the cache is to append a dummy query parameter, like `?` or `&`. With this you can re-try the url redirect to determine if it is unique per request.
+However, we have not found a way to disable the cache like this in chrome's extension API. It is possible to intercept the redirect, but if you redirect back to the original URL, you fetch from the cache again.
+One hack to disable the cache is to append a dummy query parameter, like `?` or `&`. With this you can re-try the URL redirect to determine if it is unique per request.
 
-If this tests positive for a tracking redirect, we can't simply bust the cache every time by appending dummy query parameters because we'd end up with urls like `https://foo.com/?&&&&&&&&&&&&&&&....`.
+If this tests positive for a tracking redirect, we can't simply bust the cache every time by appending dummy query parameters because we'd end up with URLs like `https://foo.com/?&&&&&&&&&&&&&&&....`.
 
 The next best solution would be to just block the request. This is yet to be implemented.
 
@@ -94,7 +94,7 @@ The next best solution would be to just block the request. This is yet to be imp
 
 ## Dependencies
 
-The packaged extension contains *no* external dependencies. However we have several local dependencies we manually update for development purposes. First, we maintain our own copy of Mozilla's Public Suffix List, and Privacy Badger's Multi-domain First Parties list. These are used to determine if a given domain is "first party" or "third party". We also have a copy of React and ReactDOM.
+The packaged extension contains *no* external dependencies. However, we have several local dependencies we manually update for development purposes. First, we maintain our own copy of Mozilla's Public Suffix List, and Privacy Badger's Multi-domain First Parties list. These are used to determine if a given domain is “first party” or “third party”. We also have a copy of React and ReactDOM.
 
 There are dependencies for development. These are all installed by running `npm install` inside `src/js`.
 
@@ -125,11 +125,11 @@ Exported stuff is assigned to properties on `exports` just like in node.
 * run `make release`, this tags the repo with the manifest version and builds a zip file
 * test the zip file in a fresh instances of supported browsers.
     - for chrome run `google-chrome --user-data-dir=$(mktemp -d)` install the zip by dragging it to the chrome://extensions/ page.
-    - for firefox run `firefox --profile $(mktemp -d) --no-remote --new-instance`. Go to `about:debugging` and click load temporary addon. Navigate to the zip file.
+    - for Firefox run `firefox --profile $(mktemp -d) --no-remote --new-instance`. Go to `about:debugging` and click load temporary add-on. Navigate to the zip file.
     - Do some basic Q&A tests, visit https://valve.github.io/fingerprintjs2/ https://reddit.com/ https://twitch.tv/ https://duckduckgo.com/
 * upload the zip.
     - for chrome visit https://chrome.google.com/webstore/developer/edit/ommfjecdpepadiafbnidoiggfpbnkfbj record any other edits to the chrome store profile in this repo
-    - for firefox visit https://addons.mozilla.org/en-US/developers/addon/privacy-possum/edit
+    - for Firefox visit https://addons.mozilla.org/en-US/developers/addon/privacy-possum/edit
 * notify users
 
 ## Testing


### PR DESCRIPTION
An answer to the nitpicky, but actually true, [its correction pull request](https://github.com/cowlicks/privacypossum/pull/232) you’ve done.

Here's the additional corrections I would like to propose : 
- [Usage of correct quotations marks](https://en.wikipedia.org/wiki/Quotation_mark#Electronic_documents). 
```Many systems, such as the personal computers of the 1980s and early 1990s, actually drew these quotes like curved closing quotes on-screen and in printouts, so text would appear like this (approximately):

    ”Good morning, Dave,” said HAL.
    ’Good morning, Dave,’ said HAL.

These same systems often drew the grave accent (`, U+0060) as an open quote glyph (actually a high-reversed-9 glyph, to preserve some usability as a grave). Thus, using a grave accent instead of a quotation mark as the opening quote gave a proper appearance of single quotes at the cost of semantic correctness. Nothing similar was available for the double quote, so many people resorted to using two single quotes for double quotes, which would look like the following:

    ‛‛Good morning, Dave,’’ said HAL.
    ‛Good morning, Dave,’ said HAL.

In languages that use the curved “…” quotation marks, they are available[b] in:

    none
[b] : in 1st or 2nd level access, i.e., specific key or using the ⇧ Shift key; not 3rd or 4th level access, i.e., using Alt Gr key or ⌥ Opt key, in conjunction or not with the ⇧ Shift key.
```
- Useless intensifier replaced by crucial. As an alternative to the over-used intensifier 'extremely', I’ve preferred using crucial, as not only it is extremely used (See that example), but it is currently used with the word 'important' which is defined by the Oxford Dictionary as : 
```Of great significance or value.
‘important habitats for wildlife’
‘it is important to avoid monosyllabic answers’
[sentence adverb] ‘the speech had passion and, more important, compassion’
```
Which is in itself, already a strong usage of the word.

- Usage of the capitalized acronym form of CDN. As it is the acronym of [`Content Delivery Network, or Content Distribution Network`](https://en.wikipedia.org/wiki/Content_delivery_network). The need of writing it in its capitalized form result of : 
[`In formal writing for a broad audience, the expansion is typically given at the first occurrence of the acronym within a given text, for the benefit of those readers who do not know what it stands for. The capitalization of the original term is independent of it being acronymized, being lowercase for a common noun such as frequently asked questions (FAQ) but uppercase for a proper noun such as the United Nations (UN) (as explained at Case > Casing of expansions). `](https://en.wikipedia.org/wiki/Acronym#Aids_to_learning_the_expansion_without_leaving_a_document)

- Missing capitalization of 'get your fingerprint' after a point.

- Usage of the capitalized acronym form of URL. As, it is the acronym of [`Uniform Resource Locator`](https://en.wikipedia.org/wiki/URL). The need of writing it in its capitalized form result of : 
[`In formal writing for a broad audience, the expansion is typically given at the first occurrence of the acronym within a given text, for the benefit of those readers who do not know what it stands for. The capitalization of the original term is independent of it being acronymized, being lowercase for a common noun such as frequently asked questions (FAQ) but uppercase for a proper noun such as the United Nations (UN) (as explained at Case > Casing of expansions). `](https://en.wikipedia.org/wiki/Acronym#Aids_to_learning_the_expansion_without_leaving_a_document)

- Correct orthography of well-known. It is either accepted as ['well known'](https://www.lexico.com/definition/well_known) or ['well-known'.](https://www.merriam-webster.com/dictionary/well-known)

- Usage of the capitalized acronym form of API. As, it is the acronym of [`Application Programming Interface`](https://en.wikipedia.org/wiki/Application_programming_interface). The need of writing it in its capitalized form result of : 
[`In formal writing for a broad audience, the expansion is typically given at the first occurrence of the acronym within a given text, for the benefit of those readers who do not know what it stands for. The capitalization of the original term is independent of it being acronymized, being lowercase for a common noun such as frequently asked questions (FAQ) but uppercase for a proper noun such as the United Nations (UN) (as explained at Case > Casing of expansions). `](https://en.wikipedia.org/wiki/Acronym#Aids_to_learning_the_expansion_without_leaving_a_document)

- Missing capitalization of 'Firefox' as it is a [proper noun](https://en.wikipedia.org/wiki/Proper_noun).